### PR TITLE
Add benchmark, some minor improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.14-alpha.0"
 authors = ["Armin Becher <armin.becher@gmail.com>"]
 edition = "2018"
 description = "Simple string matching  with questionmark and star wildcard operator."
-keywords = [ "globbing", "matching", "questionmark", "star", "string-matching"]
+keywords = ["globbing", "matching", "questionmark", "star", "string-matching"]
 readme = "README.md"
 license = "MIT"
 categories = ["algorithms"]
@@ -14,3 +14,9 @@ repository = "https://github.com/becheran/wildmatch"
 
 [dev-dependencies]
 ntest = "0.7.3"
+criterion = "0.3.4"
+regex = "1.4.3"
+
+[[bench]]
+name = "patterns"
+harness = false

--- a/benches/patterns.rs
+++ b/benches/patterns.rs
@@ -1,0 +1,69 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use regex::Regex;
+use wildmatch::WildMatch;
+
+const TEXT: &str = "Lorem ipsum dolor sit amet, \
+consetetur sadipscing elitr, sed diam nonumy eirmod tempor \
+invidunt ut labore et dolore magna aliquyam erat, sed diam \
+voluptua. At vero eos et accusam et justo duo dolores et ea \
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est \
+Lorem ipsum dolor sit amet.";
+
+const TEXT_PATTERN: &str = TEXT;
+const TEXT_REGEX: &str = "^Lorem ipsum dolor sit amet, \
+consetetur sadipscing elitr, sed diam nonumy eirmod tempor \
+invidunt ut labore et dolore magna aliquyam erat, sed diam \
+voluptua\\. At vero eos et accusam et justo duo dolores et ea \
+rebum\\. Stet clita kasd gubergren, no sea takimata sanctus est \
+Lorem ipsum dolor sit amet\\.$";
+
+const COMPLEX_PATTERN: &str = "Lorem?ipsum*dolore*ea* ?????ata*.";
+const COMPLEX_REGEX: &str = "^Lorem.ipsum.*dolore.*ea.* .....ata.*\\.$";
+
+const MOST_COMPLEX_PATTERN: &str = "?a*b*?**c?d****?e*f*g*?*h?i*?*?**j*******k";
+const MOST_COMPLEX_REGEX: &str =
+    "^.a.*b.*..*.*c.d.*.*.*.*.e.*f.*g.*..*h.i.*..*..*.*j.*.*.*.*.*.*.*k$";
+
+pub fn compiling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compiling");
+
+    group.bench_function("compile text pattern", |b| {
+        b.iter(|| WildMatch::new(black_box(TEXT_PATTERN)))
+    });
+    group.bench_function("compile complex pattern", |b| {
+        b.iter(|| WildMatch::new(black_box(MOST_COMPLEX_PATTERN)))
+    });
+
+    group.bench_function("compile text regex", |b| {
+        b.iter(|| Regex::new(black_box(TEXT_REGEX)).unwrap())
+    });
+    group.bench_function("compile complex regex", |b| {
+        b.iter(|| Regex::new(black_box(MOST_COMPLEX_REGEX)).unwrap())
+    });
+}
+
+pub fn matching(c: &mut Criterion) {
+    let pattern1 = WildMatch::new(TEXT_PATTERN);
+    let pattern2 = WildMatch::new(COMPLEX_PATTERN);
+    let regex1 = Regex::new(TEXT_REGEX).unwrap();
+    let regex2 = Regex::new(COMPLEX_REGEX).unwrap();
+
+    let mut group = c.benchmark_group("matching");
+
+    group.bench_function("match text pattern", |b| {
+        b.iter(|| pattern1 == black_box(TEXT))
+    });
+    group.bench_function("match complex pattern", |b| {
+        b.iter(|| pattern2 == black_box(TEXT))
+    });
+
+    group.bench_function("match text regex", |b| {
+        b.iter(|| regex1.is_match(black_box(TEXT)))
+    });
+    group.bench_function("match complex regex", |b| {
+        b.iter(|| regex2.is_match(black_box(TEXT)))
+    });
+}
+
+criterion_group!(benches, compiling, matching);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,10 @@
 //! assert!(!WildMatch::new("?").is_match("cat"));
 //! ```
 
+use std::fmt;
+
 /// Wildcard matcher used to match strings.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct WildMatch {
     pattern: Vec<State>,
 }
@@ -37,16 +39,23 @@ struct State {
     has_wildcard: bool,
 }
 
-impl ToString for WildMatch {
-    fn to_string(&self) -> String {
-        return self.pattern.iter().filter_map(|f| f.next_char).collect();
+impl fmt::Display for WildMatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use std::fmt::Write;
+
+        for state in &self.pattern {
+            if let Some(c) = state.next_char {
+                f.write_char(c)?;
+            }
+        }
+        Ok(())
     }
 }
 
 impl WildMatch {
     /// Constructor with pattern which can be used for matching.
     pub fn new(pattern: &str) -> WildMatch {
-        let mut simplified: Vec<State> = Vec::new();
+        let mut simplified: Vec<State> = Vec::with_capacity(pattern.len());
         let mut prev_was_star = false;
         for current_char in pattern.chars() {
             match current_char {
@@ -64,7 +73,7 @@ impl WildMatch {
             }
         }
 
-        if pattern.chars().count() > 0 {
+        if !pattern.is_empty() {
             let final_state = State {
                 next_char: None,
                 has_wildcard: prev_was_star,
@@ -113,7 +122,13 @@ impl WildMatch {
                 }
             }
         }
-        return self.pattern.get(pattern_idx).unwrap().next_char.is_none();
+        self.pattern[pattern_idx].next_char.is_none()
+    }
+}
+
+impl<'a> PartialEq<&'a str> for WildMatch {
+    fn eq(&self, &other: &&'a str) -> bool {
+        self.is_match(other)
     }
 }
 


### PR DESCRIPTION
This adds a benchmark to compare wildmatch with [regex](https://docs.rs/regex/1.4.3/regex/). It also implements minor optimizations:

* Use `Vec::with_capacity` to reduce the number of allocations
* Use `Vec::is_empty`, instead of counting the chars, which is inefficient

It also implements some useful traits:

* `impl Default for WildMatch` allows creating a default WildMatch, which matches the empty string
* `impl Display for WildMatch` allows formatting the type with `format!("{}", wild_match)`. Types implementing `Display` automatically implement `ToString`, so it's recommended to implement `Display` manually, but not `ToString`
* `impl PartialEq<&str> for WildMatch` allows comparing a WildMatch and a &str with the `==` operator. This is more convenient than `.is_match()`.

## Benchmark results

The benchmarks measure both the time it takes to compile a pattern/regex and the time the matching takes.

| Benchmark | Time|
| ---- | ----:|
| compiling/text pattern | 1,060 ns
| compiling/text regex | 384,300 ns
| compiling/complex pattern | 137 ns
| compiling/complex regex | 254,610 ns
| matching/text pattern | 828 ns
| matching/text regex | 1,782 ns
| matching/complex pattern | 1,394 ns
| matching/complex regex | 597 ns

This shows that, while Regex can be faster at matching strings, it is much, much slower at compiling a pattern than WildMatch. The performance is really impressive.