### PR TITLE
Also include stars when formatting WildMatch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ impl fmt::Display for WildMatch {
 
         for state in &self.pattern {
             if let Some(c) = state.next_char {
+                if state.has_wildcard {
+                    f.write_char('*')?;
+                }
                 f.write_char(c)?;
             }
         }
@@ -271,6 +274,18 @@ mod tests {
     fn to_string_f() {
         let m = WildMatch::new("F");
         assert_eq!("F", m.to_string());
+    }
+
+    #[test]
+    fn to_string_with_star() {
+        assert_eq!("a*bc", WildMatch::new("a*bc").to_string());
+        assert_eq!("a*bc", WildMatch::new("a**bc").to_string());
+    }
+
+    #[test]
+    fn to_string_with_question_sign() {
+        assert_eq!("a?bc", WildMatch::new("a?bc").to_string());
+        assert_eq!("a??bc", WildMatch::new("a??bc").to_string());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,10 @@ impl fmt::Display for WildMatch {
         use std::fmt::Write;
 
         for state in &self.pattern {
+            if state.has_wildcard {
+                f.write_char('*')?;
+            }
             if let Some(c) = state.next_char {
-                if state.has_wildcard {
-                    f.write_char('*')?;
-                }
                 f.write_char(c)?;
             }
         }
@@ -280,6 +280,7 @@ mod tests {
     fn to_string_with_star() {
         assert_eq!("a*bc", WildMatch::new("a*bc").to_string());
         assert_eq!("a*bc", WildMatch::new("a**bc").to_string());
+        assert_eq!("a*bc*", WildMatch::new("a*bc*").to_string());
     }
 
     #[test]


### PR DESCRIPTION
I'm relying on turning the `WildMatch` into a string for GUI purposes. The stars didn't appear in the string before.