### PR TITLE
Allows specifying wildcard characters as generic arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wildmatch"
-version = "2.1.1-alpha.0"
+version = "2.2.1-alpha.0"
 authors = ["Armin Becher <armin.becher@gmail.com>"]
 edition = "2018"
-description = "Simple string matching  with questionmark and star wildcard operator."
+description = "Simple string matching  with single-character and multi-character wildcard operator."
 keywords = ["globbing", "matching", "questionmark", "star", "string-matching"]
 readme = "README.md"
 license = "MIT"

--- a/benches/patterns.rs
+++ b/benches/patterns.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use regex::Regex;
-use wildmatch::WildMatch;
+use wildmatch::GlobWildMatch;
 use glob::Pattern;
 
 const TEXT: &str = "Lorem ipsum dolor sit amet, \
@@ -29,10 +29,10 @@ pub fn compiling(c: &mut Criterion) {
     let mut group = c.benchmark_group("compiling");
 
     group.bench_function("compile text (wildmatch)", |b| {
-        b.iter(|| WildMatch::new(black_box(FULL_TEXT_PATTERN)))
+        b.iter(|| GlobWildMatch::new(black_box(FULL_TEXT_PATTERN)))
     });
     group.bench_function("compile complex (wildmatch)", |b| {
-        b.iter(|| WildMatch::new(black_box(MOST_COMPLEX_PATTERN)))
+        b.iter(|| GlobWildMatch::new(black_box(MOST_COMPLEX_PATTERN)))
     });
 
     group.bench_function("compile text (regex)", |b| {
@@ -51,8 +51,8 @@ pub fn compiling(c: &mut Criterion) {
 }
 
 pub fn matching(c: &mut Criterion) {
-    let pattern1 = WildMatch::new(FULL_TEXT_PATTERN);
-    let pattern2 = WildMatch::new(COMPLEX_PATTERN);
+    let pattern1 = GlobWildMatch::new(FULL_TEXT_PATTERN);
+    let pattern2 = GlobWildMatch::new(COMPLEX_PATTERN);
     let regex1 = Regex::new(FULL_TEXT_REGEX).unwrap();
     let regex2 = Regex::new(COMPLEX_REGEX).unwrap();
     let glob1 = Pattern::new(FULL_TEXT_PATTERN).unwrap();

--- a/benches/patterns.rs
+++ b/benches/patterns.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use glob::Pattern;
 use regex::Regex;
 use wildmatch::GlobWildMatch;
-use glob::Pattern;
 
 const TEXT: &str = "Lorem ipsum dolor sit amet, \
 consetetur sadipscing elitr, sed diam nonumy eirmod tempor \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! assert!(!GlobWildMatch::new("????").matches("cat"));
 //! assert!(!GlobWildMatch::new("?").matches("cat"));
 //! ```
-//! 
+//!
 //! You can specify custom `char` values for the single and multi-character
 //! wildcards. For example, to use `%` as the multi-character wildcard and
 //! `_` as the single-character wildcard:
@@ -44,7 +44,7 @@ use std::fmt;
 pub type GlobWildMatch = WildMatch<'*', '?'>;
 
 /// Wildcard matcher used to match strings.
-/// 
+///
 /// `MULTI_WILDCARD` is the character used to represent a
 /// multiple-character wildcard (e.g., `*`), and `SINGLE_WILDCARD` is the
 /// character used to represent a single-character wildcard (e.g., `?`).
@@ -60,7 +60,9 @@ struct State {
     has_wildcard: bool,
 }
 
-impl <const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> fmt::Display for WildMatch<MULTI_WILDCARD, SINGLE_WILDCARD> {
+impl<const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> fmt::Display
+    for WildMatch<MULTI_WILDCARD, SINGLE_WILDCARD>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use std::fmt::Write;
 
@@ -76,7 +78,9 @@ impl <const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> fmt::Display for 
     }
 }
 
-impl <const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> WildMatch<MULTI_WILDCARD, SINGLE_WILDCARD> {
+impl<const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char>
+    WildMatch<MULTI_WILDCARD, SINGLE_WILDCARD>
+{
     /// Constructor with pattern which can be used for matching.
     pub fn new(pattern: &str) -> WildMatch<MULTI_WILDCARD, SINGLE_WILDCARD> {
         let mut simplified: Vec<State> = Vec::with_capacity(pattern.len());
@@ -199,7 +203,9 @@ impl <const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> WildMatch<MULTI_W
     }
 }
 
-impl<'a, const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> PartialEq<&'a str> for WildMatch<MULTI_WILDCARD, SINGLE_WILDCARD> {
+impl<'a, const MULTI_WILDCARD: char, const SINGLE_WILDCARD: char> PartialEq<&'a str>
+    for WildMatch<MULTI_WILDCARD, SINGLE_WILDCARD>
+{
     fn eq(&self, &other: &&'a str) -> bool {
         self.matches(other)
     }


### PR DESCRIPTION
Hi,

Thanks for writing this crate! 

I've been working on `LIKE` matching in SQL, which is similar to what this crate does but uses `%` instead of `*` and `_` instead of `?`. This PR allows specifying the wildcard characters are generic arguments to `WildMatch`.

I also added a new typedef `GlobWildMatch`, which preserves the old behavior.
