### PR TITLE
Introduce no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["algorithms"]
 repository = "https://github.com/becheran/wildmatch"
 
 [dependencies]
+tinyvec = { version = "1.6", default-features = false, features = ["alloc"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -20,7 +21,10 @@ regex = { version = "1.4.3", default-features = false }
 glob = { version = "0.3.0", default-features = false }
 
 [features]
-serde = ["dep:serde"]
+default = ["std"]
+std = ["serde?/std"]
+no_std = ["dep:tinyvec"]
+serde = ["dep:serde", "tinyvec?/serde"]
 
 [[bench]]
 name = "patterns"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ repository = "https://github.com/becheran/wildmatch"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-ntest = "0.7.3"
-criterion = "0.3.4"
-regex = "1.4.3"
-glob = "0.3.0"
+ntest = { version = "0.7.3", default-features = false }
+criterion = { version = "0.3.4", default-features = false }
+regex = { version = "1.4.3", default-features = false }
+glob = { version = "0.3.0", default-features = false }
 
 [features]
 serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["algorithms"]
 repository = "https://github.com/becheran/wildmatch"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ntest = { version = "0.7.3", default-features = false }


### PR DESCRIPTION
To be honest, I think this makes little sense for this library.
I did it, because I never implemented it before, and wanted to try.

I also did something that is discouraged:
Having a `no_std` feature which has to be manually enabled
whenever feature `std` is disabled.
This allows to not compile dependency `tinyvec` when
feature `std` is enabled.
The alternative would be, to remove the `optional = true`
from `tinyvec` in Cargo.toml,
remove feature `no_std`,
and live with `tinyvec` being compiled in the `std` case,
even though it is not used there.

I can imagine this would be ok to have around
as a separate branch in this repo,
but would probably not merge it into master.