### PR TITLE
unify example pattern used in WildMatchPattern examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,13 +69,13 @@ pub type WildMatch = WildMatchPattern<'*', '?'>;
 /// ```
 /// # use wildmatch::WildMatchPattern;
 /// // ✅ Compiles fine.
-/// WildMatchPattern::<'*', '?'>::new("*cat?");
+/// WildMatchPattern::<'*', '?'>::new("");
 /// ```
 ///
 /// ```
 /// # use wildmatch::WildMatchPattern;
 /// // ✅ Compiles fine.
-/// WildMatchPattern::<'*', '?'>::new_case_insensitive("*cat?");
+/// WildMatchPattern::<'*', '?'>::new_case_insensitive("");
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Default)]


### PR DESCRIPTION
It bugged me that I gave you a PR but it was ever so slightly imperfect.

There were two approaches, make the compile_fail examples use cat/dog to match with your other examples, or make both use empty string.

I opted for empty string since any value just isn't relevant to the test and may be misleading, I think an empty string conveys this better.